### PR TITLE
Use node-dashdash to parse arguments and options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-var args = process.argv.slice(2);
 var path = require('path')
 var fs = require('fs')
 var _ = require('underscore')

--- a/index.js
+++ b/index.js
@@ -11,10 +11,8 @@ module.exports = (function (){
   parser.parse()
   parser.validate()
   
-  //TODO: use node-dash-dash for command line parshing, --chai, --sinon
-  var name = args[0] || 'default'
-  var p = args[1] || 'psionic-matrix' 
-  if (isCliArgument(p)){ p = 'psionic-matrix'}
+  var name = parser.parseResults._args[0] || 'default'
+  var p = parser.parseResults._args[1] || 'psionic-matrix'
 
   var options = {}
 
@@ -32,9 +30,4 @@ module.exports = (function (){
 
   }
   return WarpPrism
-
-  function isCliArgument(str){
-    var bool = (str.charAt(0) == '-')
-    return bool
-  }
 })()


### PR DESCRIPTION
Hi @lingqingmeng! Node-dashdash removes the need to access the process.argv object directly because it already separates arguments and options. The arguments should now be accessed from the dashdash parser's results.